### PR TITLE
Fix fatal error in sitemaps

### DIFF
--- a/src/Data/Entry.php
+++ b/src/Data/Entry.php
@@ -19,7 +19,6 @@ class Entry
         return EntryFacade::query()
             ->where('collection', $collectionHandle)
             ->where('site', $site)
-            ->whereJsonDoesntContain('data', ['noindex_page' => true])
             ->get();
     }
 }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -3,9 +3,11 @@
 namespace Elaniin\Findable\Sitemap;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Spatie\Sitemap\Sitemap as SpatieSitemap;
 use Spatie\Sitemap\Tags\Url;
-use Illuminate\Support\Collection;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Entries\EntryCollection;
 use Statamic\Facades\Site;
 
 class Sitemap
@@ -41,18 +43,22 @@ class Sitemap
      * @param EntryCollection $entries
      * @return SpatieSitemap
      */
-    public static function collection(\Statamic\Entries\EntryCollection $entries)
+    public static function collection(EntryCollection $entries)
     {
         $sitemap = SpatieSitemap::create();
 
-        $entries->each(function ($entry) use ($sitemap) {
-            $sitemap->add(
-                Url::create($entry->url())
-                    ->setChangeFrequency('')
-                    ->setPriority(0)
-                    ->setLastModificationDate(Carbon::createFromTimestamp($entry->lastModified()))
-            );
-        });
+        $entries
+            ->filter(function (Entry $entry) {
+                return $entry->get('noindex_page') !== true;
+            })
+            ->each(function (Entry $entry) use ($sitemap) {
+                $sitemap->add(
+                    Url::create($entry->url())
+                        ->setChangeFrequency('')
+                        ->setPriority(0)
+                        ->setLastModificationDate(Carbon::createFromTimestamp($entry->lastModified()))
+                );
+            });
 
         return $sitemap;
     }


### PR DESCRIPTION
Fixes the fatal error caused by calling `whereJsonDoesntContain()` in `Statamic\Stache\Query\EntryQueryBuilder`. This happens for installations that do not use Eloquent to save entries.